### PR TITLE
Patched Fix CWE-670: Always-Incorrect Control Flow Implementation disabling eval not applied consistently in renderers with sandbox disabled

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8185,10 +8185,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@*, electron@22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.0.0.tgz#ef84ab9cf23aa3f8c2f42a1e8e000ad7fd941058"
-  integrity sha512-cgRc4wjyM+81A0E8UGv1HNJjL1HBI5cWNh/DUIjzYvoUuiEM0SS0hAH/zaFQ18xOz2ced6Yih8SybpOiOYJhdg==
+electron@*, electron@22.3.24:
+  version "22.3.24"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.24.tgz#14479cf11cf4709f78d324015429fa82492c2150"
+  integrity sha512-wnGsShoRVk1Jmgr7h/jZK9bI5UwMF88sdQ5c8z2j2N8B9elhF/jKDFjwDXUrY1Y0xzAskOP0tYIDE+UbUM4byQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
This project used is a framework electron which lets you write cross-platform desktop applications using JavaScript, HTML and CSS. A Content-Security-Policy that disables eval, specifically setting a `script-src` directive and _not_ providing `unsafe-eval` in that directive, is not respected in renderers that have sandbox disabled. i.e. `sandbox: false` in the `webPreferences` object. This allows usage of methods like `eval()` and `new Function` unexpectedly which can result in an expanded attack surface. This issue only ever affected the 22 and 23 major versions of Electron and has been fixed in the latest versions of those release lines. Specifically, these versions contain the fixes: 22.0.1 and 23.0.0-alpha.2 We recommend all apps upgrade to the latest stable version of Electron. If upgrading isn't possible, this issue can be addressed without upgrading by enabling `sandbox: true` on all renderers.


```js
  // If we're running with contextIsolation enabled in the renderer process,
  // fall back to Blink's logic.
  if (node::Environment::GetCurrent(context) == nullptr) {
  describe('csp in sandbox: false', () => {
    it('is correctly applied', async () => {
      const w = new BrowserWindow({
        show: false,
        webPreferences: { sandbox: false }
```

## Impact
A Content-Security-Policy that disables eval, specifically setting a script-src directive and not providing unsafe-eval in that directive, is not respected in renderers that have sandbox and contextIsolation disabled. i.e. sandbox: false and contextIsolation: false in the webPreferences object. This resulted in incorrectly allowing usage of methods like eval() and new Function, which can result in an expanded attack surface.

CWE-670
**`CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H`**
CVE-2023-23623
